### PR TITLE
Move BuildTools to the top of PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ alternative it is possible to create a batch file which will temporarily modify 
 Here's an example of such file:
 
     @echo off
-    set PATH=%PATH%;C:\BuildTools\bin
+    set PATH=C:\BuildTools\bin;%PATH%
     bash build.sh
 
 To launch a build process without a batch, simply execute


### PR DESCRIPTION
This resolves as issue for Windows users with WSL installed where
`PLATFORM` is getting set to `linux` instead of `vc-win32` because the
WSL bash.exe is being used instead of the BuildTools bash.exe.