### PR TITLE
Added support for UTexCoordSource material class

### DIFF
--- a/Exporters/ExportPsk.cpp
+++ b/Exporters/ExportPsk.cpp
@@ -306,6 +306,29 @@ static void ExportExtraUV
 	unguard;
 }
 
+static void ExportVertexNormals(FArchive &Ar, const TArray<CPackedNormal> &Normals)
+{
+	guard(ExportVertexNormals);
+
+	static VChunkHeader NormalHdr;
+	NormalHdr.DataCount = Normals.Num();
+	NormalHdr.DataSize = sizeof(CVec3);
+
+	SAVE_CHUNK(NormalHdr, "VTXNORMS");
+	for (int i = 0; i < Normals.Num(); i++)
+	{
+		CVec3 Normal;
+		Unpack(Normal, Normals[i]);
+		Normal.Normalize();
+#if MIRROR_MESH
+		Normal.Y = -Normal.Y;
+#endif
+		Ar << Normal.X << Normal.Y << Normal.Z;
+	}
+
+	unguard;
+}
+
 static void CopyBoneName(char* Dst, int DstLen, const char* Src)
 {
 	int NameLength = strlen(Src);
@@ -445,6 +468,7 @@ static void ExportSkeletalMeshLod(const CSkeletalMesh &Mesh, const CSkelMeshLod 
 
 	ExportVertexColors(Ar, Lod.VertexColors, Lod.NumVerts);
 	ExportExtraUV(Ar, Lod.ExtraUV, Lod.NumVerts, Lod.NumTexCoords);
+	ExportVertexNormals(Ar, Share.Normals);
 
 /*	if (!GExportPskx)						// nothing more to write
 		return;
@@ -884,6 +908,7 @@ static void ExportStaticMeshLod(const CStaticMeshLod &Lod, FArchive &Ar)
 
 	ExportVertexColors(Ar, Lod.VertexColors, Lod.NumVerts);
 	ExportExtraUV(Ar, Lod.ExtraUV, Lod.NumVerts, Lod.NumTexCoords);
+	ExportVertexNormals(Ar, Share.Normals);
 
 	unguard;
 }

--- a/Exporters/Psk.h
+++ b/Exporters/Psk.h
@@ -2,7 +2,7 @@
 #define __PSK_H__
 
 
-#define PSK_VERSION		20100422
+#define PSK_VERSION		20210917 // VTXNORMS chunk
 #define PSA_VERSION		20100422
 
 /******************************************************************************

--- a/Unreal/UnrealMaterial/UnMaterial2.h
+++ b/Unreal/UnrealMaterial/UnMaterial2.h
@@ -961,6 +961,20 @@ public:
 	END_PROP_TABLE
 };
 
+class UTexCoordSource : public UTexModifier
+{
+	DECLARE_CLASS(UTexCoordSource, UTexModifier);
+public:
+	int				SourceChannel;
+
+	UTexCoordSource()
+	:	SourceChannel(1)
+	{}
+
+	BEGIN_PROP_TABLE
+		PROP_INT(SourceChannel)
+	END_PROP_TABLE
+};
 
 enum ETexEnvMapType
 {
@@ -1346,6 +1360,7 @@ public:
 	REGISTER_CLASS(UTexture)			\
 	REGISTER_CLASS(UCubemap)			\
 	REGISTER_CLASS(UFinalBlend)			\
+	REGISTER_CLASS(UTexCoordSource)		\
 	REGISTER_CLASS(UTexEnvMap)			\
 	REGISTER_CLASS(UTexOscillator)		\
 	REGISTER_CLASS(UTexPanner)			\


### PR DESCRIPTION
This adds support for the `UTexCoordSource` class which was inexplicably missing from the supported material types.