### PR TITLE
[Accepted] Fix -psk not working

### DIFF
--- a/UmodelTool/Main.cpp
+++ b/UmodelTool/Main.cpp
@@ -861,7 +861,7 @@ int main(int argc, const char **argv)
 		{
 			GSettings.Export.SkeletalMeshFormat = GSettings.Export.StaticMeshFormat = EExportMeshFormat::psk;
 		}
-		if (!stricmp(opt, "png"))
+		else if (!stricmp(opt, "png"))
 		{
 			GSettings.Export.TextureFormat = ETextureExportFormat::png;
 			//!! todo: also screenshots


### PR DESCRIPTION
-psk doesn't seem to work because it is not in the else block of if elses, which leads to it thinking an invalid command was entered. This is inconsistent with the documentation.

To repro, attempt to export with the -psk switch. I tested on the latest october 2022 release build.

An example command I used:
```
C:\Users\mgame\AppData\Roaming\LegendaryExplorer\staticexecutables\umodel\umodel.exe -export -psk -out="C:\Users\mgame\Desktop" "E:\SteamLibrary\steamapps\common\Mass Effect Legendary Edition\Game\ME2\BioGame\DLC\DLC_METR_Patch01\CookedPCConsole\BioD_ProCer_100RezRoom.pcc" Locker03 StaticMesh
UModel: bad command line: invalid option: -psk
Try "umodel -help" for more information.
```

This exact same command works fine if I use -gltf.