### PR TITLE
Set FileVersion = GForcePackageVersion when present

### DIFF
--- a/Unreal/UnrealPackage/UnPackage4.cpp
+++ b/Unreal/UnrealPackage/UnPackage4.cpp
@@ -112,6 +112,9 @@ void FPackageFileSummary::Serialize4(FArchive &Ar)
 	FileVersion     = Version & 0xFFFF;
 	LicenseeVersion = LicenseeVersion & 0xFFFF;
 
+	if (GForcePackageVersion)
+		FileVersion = GForcePackageVersion;
+
 	// store file version to archive
 	Ar.ArVer         = FileVersion;
 	Ar.ArLicenseeVer = LicenseeVersion;


### PR DESCRIPTION
I'll be blunt... I don't remember why I made this change. I am confident it was necessary to load some file I was pulling game audio out of, months to years ago, but that's all I can remember. I'm cleaning up my local source tree and wanted to preserve this for posterity. I won't be offended if you close this; it will still be findable when someone hits the same problem in the future and comes searching for a solution.